### PR TITLE
Handle negative inputs in aoc helpers

### DIFF
--- a/aoc/__init__.py
+++ b/aoc/__init__.py
@@ -20,6 +20,8 @@ def integer_compositions(n):
   Returns an iterator over the compositions of the given integer n.
   Example: n=3 -> 3 = 2+1 = 1+2 = 1+1+1.
   """
+  if n < 0:
+    raise ValueError("n must be non-negative")
   if n == 0:
     yield []
   else:
@@ -29,6 +31,10 @@ def integer_compositions(n):
         yield [i] + composition
 
 def to_binary(n, length):
+  if n < 0:
+    raise ValueError("n must be non-negative")
+  if length < 0:
+    raise ValueError("length must be non-negative")
   return ("0" * length + bin(n)[2:])[-length:]
 
 def extrapolate(it, goal):

--- a/tests/test_aoc_lib.py
+++ b/tests/test_aoc_lib.py
@@ -1,0 +1,31 @@
+import pytest
+import sys
+import pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import aoc
+
+
+def test_integer_compositions_basic():
+    result = list(aoc.integer_compositions(3))
+    assert result == [[3], [2, 1], [1, 2], [1, 1, 1]]
+
+
+def test_integer_compositions_negative():
+    with pytest.raises(ValueError):
+        list(aoc.integer_compositions(-1))
+
+
+def test_to_binary_basic():
+    assert aoc.to_binary(5, 4) == "0101"
+
+
+def test_to_binary_negative():
+    with pytest.raises(ValueError):
+        aoc.to_binary(-5, 4)
+
+
+def test_bounds():
+    b = aoc.bounds([(0, 0), (2, 3), (-1, 4)])
+    assert (b.ymin, b.ymax, b.xmin, b.xmax) == (-1, 2, 0, 4)
+


### PR DESCRIPTION
## Summary
- ensure `integer_compositions` and `to_binary` reject negative values
- add unit tests for `integer_compositions`, `to_binary` and `bounds`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897b9591394832f952649426176ce85